### PR TITLE
Add installation instructions for TypeScript users to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Install with ``npm``:
 ``` sh
 npm install coinbase-commerce-node --save
 ```
+
+Type definitions are available for TypeScript users:
+```sh
+npm install @types/coinbase-commerce-node --save-dev
+```
 ## Usage
 ``` js
 var coinbase = require('coinbase-commerce-node');


### PR DESCRIPTION
Added installation instructions for package type definitions. ([`@types/coinbase-commerce-node`](https://www.npmjs.com/package/@types/coinbase-commerce-node))

With the increased adoption of TypeScript, I feel it is important to let users know that you do have type definitions available as it makes life a lot more convenient for most developers. 😅