### PR TITLE
Handle errors of parsing JSON response.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -132,7 +132,14 @@ module.exports = (function (DEFAULT_API_KEY, DEFAULT_BASE_API_URL, DEFAULT_API_V
 
 		function makeRequest(options, callback) {
 			request(options, function (error, response) {
-				var apiResponse = new ApiResponse(response);
+				var apiResponse;
+
+				try {
+					apiResponse = new ApiResponse(response);
+				} catch (e) {
+					callback(e, apiResponse);
+					return;
+				}
 
 				if (!buildApiError(error, apiResponse, callback)) {
 					callback(null, apiResponse);


### PR DESCRIPTION
Your library has a problem when a response from coinbase service is not JSON in case of error. Then promises from your library are not rejected and this causes an uncaught exception in Node.js application. Here is a fix for the problem.